### PR TITLE
Set up route around flood reports

### DIFF
--- a/database/dbindex.js
+++ b/database/dbindex.js
@@ -48,7 +48,8 @@ const getReports = (() => {
   // const text = 'SELECT latLng, img, description, physical_address FROM reports';
   pool.query('SELECT latLng, img, description, physical_address FROM reports')
     .then((reports) => {
-      console.log(reports);
+      console.log(reports.rows);
+      return reports.rows;
     })
     .catch((error) => {
       console.log(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,1337 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "requires": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "requires": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "requires": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "requires": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+    },
+    "@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "requires": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "requires": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+        },
+        "@turf/invariant": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        }
+      }
+    },
+    "@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "requires": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "requires": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      },
+      "dependencies": {
+        "@turf/bearing": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
+          "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/clone": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
+          "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/distance": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
+          "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+        },
+        "@turf/invariant": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/projection": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
+          "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
+          "requires": {
+            "@turf/clone": "6.x",
+            "@turf/helpers": "6.x",
+            "@turf/meta": "6.x"
+          }
+        },
+        "@turf/rhumb-bearing": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
+          "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/rhumb-distance": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
+          "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        }
+      }
+    },
+    "@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "requires": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "requires": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "requires": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "requires": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "requires": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "requires": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -221,11 +1552,43 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concaveman": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
+      "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
+      "requires": {
+        "monotone-convex-hull-2d": "^1.0.1",
+        "point-in-polygon": "^1.0.1",
+        "rbush": "^2.0.1",
+        "robust-orientation": "^1.1.3",
+        "tinyqueue": "^1.1.0"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
     },
     "confusing-browser-globals": {
       "version": "1.0.9",
@@ -296,12 +1659,43 @@
         }
       }
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "deep-is": {
@@ -317,6 +1711,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
     },
     "depd": {
       "version": "1.1.2",
@@ -341,6 +1740,11 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
       "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
+    },
+    "earcut": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
+      "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -789,6 +2193,29 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "requires": {
+        "deep-equal": "^1.0.0"
+      }
+    },
+    "geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "requires": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -932,6 +2359,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1055,6 +2487,11 @@
         "nan": "^2.14.0"
       }
     },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -1146,6 +2583,14 @@
         "minimist": "0.0.8"
       }
     },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1221,6 +2666,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -1497,6 +2947,11 @@
         "find-up": "^2.1.0"
       }
     },
+    "point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
     "postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -1552,6 +3007,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1566,6 +3026,14 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "requires": {
+        "quickselect": "^2.0.0"
       }
     },
     "read-pkg": {
@@ -1607,6 +3075,14 @@
         }
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -1646,6 +3122,36 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
     "run-async": {
       "version": "2.3.0",
@@ -1744,6 +3250,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -1925,6 +3436,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -1939,11 +3455,42 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "topojson-client": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.1.tgz",
+      "integrity": "sha512-rfGGzyqefpxOaxvV9OTF9t+1g+WhjGEbAIuCcmKYrQkxr0nttjMMyzZsK+NhLW4cTl2g1bz2jQczPUtEshpbVQ==",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "requires": {
+        "commander": "2"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Flood-With-Friends/floodBackEnd#readme",
   "dependencies": {
+    "@turf/turf": "^5.1.6",
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",

--- a/server/APIhelpers.js
+++ b/server/APIhelpers.js
@@ -10,10 +10,26 @@ const createAddress = (coord) =>
   // need to take latLng coord and convert to physical address in words through API call to
   // google geoCode.
   axios.get(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${coord}&key=${GOOGLE_APIKEY}`)
-    .then((physicalAddress) => 
-    physicalAddress.data.results[0].formatted_address);
+    .then((physicalAddress) => physicalAddress.data.results[0].formatted_address);
+
+const formatWaypoints = ((routeCoordsArray) => {
+  let string = '';
+  for (let i = 0; i < routeCoordsArray.length; i += 1) {
+    if (i === routeCoordsArray.length - 1) {
+      string += `${parseFloat(routeCoordsArray[i][1])},${parseFloat(routeCoordsArray[i][0])}`;
+      // string.slice(0, (string.length - 1));
+    } else {
+      string += `${parseFloat(routeCoordsArray[i][1])},${parseFloat(routeCoordsArray[i][0])}|`;
+    }
+  }
+  return string;
+  // routeCoordsArray.forEach(coord => {
+  //   string += parseFloat(coord[1]) + ',' + parseFloat(coord[0]) + "|"
+  // });
+});
 
 module.exports = {
   getRainfall,
   createAddress,
+  formatWaypoints,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -53,6 +53,8 @@ app.get('/map', (req, res) => {
   const result = routeCoordsArray.map((coordPair) => ({ location: { lat: coordPair[1], lng: coordPair[0] } }));
   directions.waypoints = result;
 
+  //send back directions object with origin, desintation, and waypoints formatted for use with agm
+  res.status(201).send(directions);
 
 
   // axios.get('https://api.openbrewerydb.org/breweries')

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,15 @@ app.get('/map', (req, res) => {
   };
 
   const route = turf.shortestPath(start, end, options);
+
+  const routeCoordsArray = route.geometry.coordinates;
+  console.log(routeCoordsArray, "this is the coords array");
+  //snap these coords to a road using google's snapToRoads API,
+  //take returned lat/lng from that API req and send it to google agm directions
+  //send the return of that to front end to render on the client side map
+  const directions = {};
+
+  
   // axios.get('https://api.openbrewerydb.org/breweries')
   //   .then((breweries) => {
   //     res.status(201).send(breweries.data);

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const axios = require('axios');
+const turf = require('@turf/turf');
 const bodyParser = require('body-parser');
 const path = require('path');
 const { insertUser, createReport, getReports } = require('../database/dbindex');
@@ -19,15 +20,19 @@ app.use(express.static(angularStaticDir));
 
 let reportData;
 
-app.get('/route', (req, res) => {
-  axios.get('https://api.openbrewerydb.org/breweries')
-    .then((breweries) => {
-      res.status(201).send(breweries.data);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.send(500);
-    });
+app.get('/map', (req, res) => {
+  const point1 = turf.point([-90.080587, 29.977581]);
+  const bufferedPoint1 = turf.buffer(point1, 0.05, { units: 'miles' });
+  const point2 = turf.point([-90.082742, 29.979062]);
+  const bufferedPoint2 = turf.buffer(point2, 0.05, { units: 'miles' });
+  // axios.get('https://api.openbrewerydb.org/breweries')
+  //   .then((breweries) => {
+  //     res.status(201).send(breweries.data);
+  //   })
+  //   .catch((err) => {
+  //     console.log(err);
+  //     res.send(500);
+  //   });
 });
 
 app.get('/rainfall', (req, res) => getRainfall()

--- a/server/index.js
+++ b/server/index.js
@@ -44,24 +44,14 @@ app.post('/submitReport', async (req, res) => {
   if (!req.body.location) {
     returnedAddress = await createAddress(req.body.report.latLng);
   }
-  // .then((returnedAddress) => {
   reportData = {
     desc: req.body.report.desc,
     latLng: req.body.report.latLng,
     img: req.body.report.img || null,
     physicalAddress: returnedAddress || req.body.location,
   };
-  // })
-  // .then(() => {
   await createReport(reportData);
-  // })
-  // .then(() => {
   res.status(201).send('got ya report...Allen');
-  // })
-  // .catch((error) => {
-  //   console.log(error);
-  //   res.status(504).send('something went wrong with your report');
-  // });
 });
 
 app.get('/addUser', (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -41,8 +41,16 @@ app.get('/map', (req, res) => {
   //take returned lat/lng from that API req and send it to google agm directions
   //send the return of that to front end to render on the client side map
   const directions = {};
+  //add origin prop in directions that takes first lat/lng from routeCoordsArray as beginning point
+  directions.origin = { lat: routeCoordsArray[0][1], lng: routeCoordsArray[0][0] };
+  //add destination prop in directions that takes last lat/lng from routeCoordsArray as ending point
+  directions.destination = { lat: routeCoordsArray[routeCoordsArray.length - 1][1], lng: routeCoordsArray[routeCoordsArray.length - 1][0] };
+  //chop off first and last lat/lng combos from routeCoordsArray so that only the middle points will be used as waypoints in directions variable
+  routeCoordsArray.shift();
+  routeCoordsArray.pop();
 
-  
+
+
   // axios.get('https://api.openbrewerydb.org/breweries')
   //   .then((breweries) => {
   //     res.status(201).send(breweries.data);

--- a/server/index.js
+++ b/server/index.js
@@ -20,17 +20,28 @@ app.use(express.static(angularStaticDir));
 
 let reportData;
 
-app.get('/map', (req, res) => {
-  const point1 = turf.point([-90.080587, 29.977581]);
-  const bufferedPoint1 = turf.buffer(point1, 0.05, { units: 'miles' });
-  const point2 = turf.point([-90.082742, 29.979062]);
+app.post('/getMap', (req, res) => {
+  console.log(req);
+  const point1 = turf.point([-90.078370, 29.976051]);
+  const bufferedPoint1 = turf.buffer(point1, 0.1, { units: 'miles' });
+  const point2 = turf.point([-90.072157, 29.971722]);
   const bufferedPoint2 = turf.buffer(point2, 0.05, { units: 'miles' });
 
-  const start = [-90.087654, 29.982425];
-  const end = [-90.073903, 29.973242];
+  // console.log(bufferedPoint1, 'this is bufferedPoint1'); // returns Object {type: "Feature", properties: Object, geometry: Object}
+
+  const obstacles = turf.featureCollection([bufferedPoint1, bufferedPoint2]);
+  console.log(obstacles, "this is obstacles");
+
+  //going to need to be the origin and desination lat/lng from the http req from front end,
+  //with obstacles = sections that are flood reports
+  // const start = [-90.087654, 29.982425];
+  // const end = [-90.073903, 29.973242];
+  const start = [parseFloat(req.body.mapReqInfo.origin.lng), parseFloat(req.body.mapReqInfo.origin.lat)];
+  const end = [parseFloat(req.body.mapReqInfo.destination.lng), parseFloat(req.body.mapReqInfo.destination.lat)];
   const options = {
     // obstacles: turf.polygon([[[-90.080587, 29.977581], [-90.080445, 29.977483], [-90.080514, 29.977549], [-90.080587, 29.977581]]]),
-    obstacles: bufferedPoint1.geometry, bufferedPoint2.geometry,
+    obstacles,
+    // : bufferedPoint1.geometry,
   };
 
   const route = turf.shortestPath(start, end, options);

--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@ const turf = require('@turf/turf');
 const bodyParser = require('body-parser');
 const path = require('path');
 const { insertUser, createReport, getReports } = require('../database/dbindex');
-const { getRainfall, createAddress } = require('./APIhelpers');
+const { getRainfall, createAddress, formatWaypoints } = require('./APIhelpers');
 
 const PORT = process.env.PORT || 8080;
 
@@ -20,52 +20,80 @@ app.use(express.static(angularStaticDir));
 
 let reportData;
 
-app.post('/getMap', (req, res) => {
-  console.log(req);
-  const point1 = turf.point([-90.078370, 29.976051]);
-  const bufferedPoint1 = turf.buffer(point1, 0.1, { units: 'miles' });
-  const point2 = turf.point([-90.072157, 29.971722]);
-  const bufferedPoint2 = turf.buffer(point2, 0.05, { units: 'miles' });
+app.post('/getMap', async (req, res) => {
+  const reports = await getReports();
+  const bufferArr = [];
+  console.log(reports, 'this is the reports');
+  // .then((reports) => console.log(reports));
+  reports.forEach((report) => {
+    if (report.latlng) {
+        const arr = report.latlng.split(',');
+        const point = turf.point([parseFloat(arr[1]), parseFloat(arr[0])]);
+        const bufferedPoint = turf.buffer(point, 0.2, { units: 'miles' });
+        bufferArr.push(bufferedPoint);
+    }
+  });
 
-  // console.log(bufferedPoint1, 'this is bufferedPoint1'); // returns Object {type: "Feature", properties: Object, geometry: Object}
+  const slimBuffer = bufferArr.splice(0, 15);
+  // const point1 = turf.point([-90.078370, 29.976051]);
+  // const bufferedPoint1 = turf.buffer(point1, 0.2, { units: 'miles' });
+  // const point2 = turf.point([-90.072157, 29.971722]);
+  // const bufferedPoint2 = turf.buffer(point2, 0.2, { units: 'miles' });
 
-  const obstacles = turf.featureCollection([bufferedPoint1, bufferedPoint2]);
-  console.log(obstacles, "this is obstacles");
+  // const obstacles = turf.featureCollection([bufferedPoint1, bufferedPoint2]);
+  const obstacles = turf.featureCollection(slimBuffer);
 
-  //going to need to be the origin and desination lat/lng from the http req from front end,
-  //with obstacles = sections that are flood reports
-  // const start = [-90.087654, 29.982425];
-  // const end = [-90.073903, 29.973242];
+  console.log(obstacles, 'this is the obstacles');
+
+  // going to need to be the origin and desination lat/lng from the http req from front end,
+  // with obstacles = sections that are flood reports
   const start = [parseFloat(req.body.mapReqInfo.origin.lng), parseFloat(req.body.mapReqInfo.origin.lat)];
   const end = [parseFloat(req.body.mapReqInfo.destination.lng), parseFloat(req.body.mapReqInfo.destination.lat)];
   const options = {
-    // obstacles: turf.polygon([[[-90.080587, 29.977581], [-90.080445, 29.977483], [-90.080514, 29.977549], [-90.080587, 29.977581]]]),
     obstacles,
-    // : bufferedPoint1.geometry,
   };
 
-  const route = turf.shortestPath(start, end, options);
+  const route = await turf.shortestPath(start, end, options);
 
   const routeCoordsArray = route.geometry.coordinates;
-  console.log(routeCoordsArray, "this is the coords array");
-  //snap these coords to a road using google's snapToRoads API,
-  //take returned lat/lng from that API req and send it to google agm directions
-  //send the return of that to front end to render on the client side map
+  console.log(routeCoordsArray, 'this is the coords array');
+  // snap these coords to a road using google's snapToRoads API,
+  // take returned lat/lng from that API req and send it to google agm directions
+  // send the return of that to front end to render on the client side map
   const directions = {};
-  //add origin prop in directions that takes first lat/lng from routeCoordsArray as beginning point
-  directions.origin = { lat: routeCoordsArray[0][1], lng: routeCoordsArray[0][0] };
-  //add destination prop in directions that takes last lat/lng from routeCoordsArray as ending point
-  directions.destination = { lat: routeCoordsArray[routeCoordsArray.length - 1][1], lng: routeCoordsArray[routeCoordsArray.length - 1][0] };
-  //chop off first and last lat/lng combos from routeCoordsArray so that only the middle points will be used as waypoints in directions variable
-  routeCoordsArray.shift();
-  routeCoordsArray.pop();
 
-  //loop through all remaining lat/lngs in routeCoordsArray and set them up as waypoints in the directions variable
-  const result = routeCoordsArray.map((coordPair) => ({ location: { lat: coordPair[1], lng: coordPair[0] } }));
-  directions.waypoints = result;
+  // 29.977153850002008, -90.0810575260374 | 29.976914788339545, -90.08119547903829 | 29.976556195845852, -90.08133343203917 | 29.97548041836477, -90.08119547903829 | 29.975121825871078, -90.0810575260374 | 29.974882764208616, -90.08091957303651 | 29.974643702546153, -90.08078162003562
+  // 29.9776764,-90.08052699999999|29.97739291166447,-90.08091957303651|29.977034319170777,-90.0810575260374|29.977153850002008,-90.0810575260374|29.976914788339545,-90.08119547903829|29.976556195845852,-90.08133343203917|29.97548041836477,-90.08119547903829|29.975121825871078,-90.0810575260374|29.974882764208616,-90.08091957303651|29.974643702546153,-90.08078162003562|29.96603748269751,-90.0709869569726|29.952085,-90.0709582
+  const allCoords = await formatWaypoints(routeCoordsArray);
+  console.log(allCoords, 'this is allCoords');
 
-  //send back directions object with origin, desintation, and waypoints formatted for use with agm
-  res.status(201).send(directions);
+  await axios.get(`https://roads.googleapis.com/v1/snapToRoads?path=${allCoords}&interpolate=false&key=AIzaSyDCQchp8XgMTPdeHQG_4EJ8ytTv7bWPP3c`)
+    .then((response) => {
+      directions.origin = { lat: response.data.snappedPoints[0].location.latitude, lng: response.data.snappedPoints[0].location.longitude };
+      directions.destination = { lat: response.data.snappedPoints[response.data.snappedPoints.length - 1].location.latitude, lng: response.data.snappedPoints[response.data.snappedPoints.length - 1].location.longitude };
+      const mapped = response.data.snappedPoints.slice(1, response.data.snappedPoints.length - 1).map((points) => ({ location: { lat: points.location.latitude, lng: points.location.longitude } }));
+      console.log('this is mapped', mapped);
+      directions.waypoints = mapped;
+      res.status(201).send(directions);
+    });
+
+
+  // THIS IS THE WORKING STUFF, CARIN! (below)!!!!!!!!
+
+  // //add origin prop in directions that takes first lat/lng from routeCoordsArray as beginning point
+  // directions.origin = { lat: routeCoordsArray[0][1], lng: routeCoordsArray[0][0] };
+  // //add destination prop in directions that takes last lat/lng from routeCoordsArray as ending point
+  // directions.destination = { lat: routeCoordsArray[routeCoordsArray.length - 1][1], lng: routeCoordsArray[routeCoordsArray.length - 1][0] };
+  // //chop off first and last lat/lng combos from routeCoordsArray so that only the middle points will be used as waypoints in directions variable
+  // routeCoordsArray.shift();
+  // routeCoordsArray.pop();
+
+  // //loop through all remaining lat/lngs in routeCoordsArray and set them up as waypoints in the directions variable
+  // const result = routeCoordsArray.map((coordPair) => ({ location: { lat: coordPair[1], lng: coordPair[0] } }));
+  // directions.waypoints = result;
+
+  // send back directions object with origin, desintation, and waypoints formatted for use with agm
+  // res.status(201).send(directions);
 
 
   // axios.get('https://api.openbrewerydb.org/breweries')

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,15 @@ app.get('/map', (req, res) => {
   const bufferedPoint1 = turf.buffer(point1, 0.05, { units: 'miles' });
   const point2 = turf.point([-90.082742, 29.979062]);
   const bufferedPoint2 = turf.buffer(point2, 0.05, { units: 'miles' });
+
+  const start = [-90.087654, 29.982425];
+  const end = [-90.073903, 29.973242];
+  const options = {
+    // obstacles: turf.polygon([[[-90.080587, 29.977581], [-90.080445, 29.977483], [-90.080514, 29.977549], [-90.080587, 29.977581]]]),
+    obstacles: bufferedPoint1.geometry, bufferedPoint2.geometry,
+  };
+
+  const route = turf.shortestPath(start, end, options);
   // axios.get('https://api.openbrewerydb.org/breweries')
   //   .then((breweries) => {
   //     res.status(201).send(breweries.data);

--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,10 @@ app.get('/map', (req, res) => {
   routeCoordsArray.shift();
   routeCoordsArray.pop();
 
+  //loop through all remaining lat/lngs in routeCoordsArray and set them up as waypoints in the directions variable
+  const result = routeCoordsArray.map((coordPair) => ({ location: { lat: coordPair[1], lng: coordPair[0] } }));
+  directions.waypoints = result;
+
 
 
   // axios.get('https://api.openbrewerydb.org/breweries')

--- a/server/index.js
+++ b/server/index.js
@@ -79,8 +79,10 @@ app.get('/addUser', (req, res) => {
 // GET req from frontend when user loads any page that renders a map.
 // This fn gets all flood reports from db, and returns them to the user.
 app.get('/floodReports', async (req, res) => {
-  const reports = await getReports();
-  res.status(201).json(reports.rows);
+  await getReports()
+    .then((reports) => {
+      res.json(reports);
+    });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
-Use Turf.js to make polygons of off-limits buffered areas that are a circumference of .5 miles around all flood reports in db. 
-Send coordinates of polygons as <obstacles> to shortestPath. Send returned coordinates to  google api snapToRoads. 
-Send return of that to front end as waypoints to use in route construction.